### PR TITLE
Mot History Display

### DIFF
--- a/app/Livewire/Vehicle/DisplayMotTests.php
+++ b/app/Livewire/Vehicle/DisplayMotTests.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Vehicle;
+
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class DisplayMotTests extends Component
+{
+    public $motTests = [];
+
+    #[On('fetched')]
+    public function fetch($motTests): void
+    {
+        $this->motTests = $motTests;
+    }
+
+    public function render()
+    {
+        return view('livewire.vehicle.display-mot-tests');
+    }
+}

--- a/app/Livewire/Vehicle/FetchVehicleDetails.php
+++ b/app/Livewire/Vehicle/FetchVehicleDetails.php
@@ -23,7 +23,6 @@ class FetchVehicleDetails extends Component
     public $revenueWeight = '-';
     public $model = '-';
     public $hasOutstandingRecall = '-';
-    public $motTests = [];
 
     #[On('searched')]
     public function fetch($vrn)
@@ -70,7 +69,8 @@ class FetchVehicleDetails extends Component
 
         $this->model = $motHistory->json('model') ?? 'Not Found';
         $this->hasOutstandingRecall = $motHistory->json('hasOutstandingRecall') ?? 'Not Found';
-        $this->motTests = $motHistory->json('motTests');
+
+        $this->dispatch('fetched', $motHistory->json('motTests'));
     }
 
     public function render()

--- a/app/Livewire/Vehicle/SearchVehicle.php
+++ b/app/Livewire/Vehicle/SearchVehicle.php
@@ -15,7 +15,7 @@ class SearchVehicle extends Component
 
     public $previousSearches = [];
 
-    public function mount()
+    public function mount(): void
     {
         $this->previousSearches = Auth::user()->searches()->limit(10)->get();
     }
@@ -28,6 +28,7 @@ class SearchVehicle extends Component
         $this->vrn = str_replace(' ', '', $this->vrn);
 
         $this->dispatch('searched', $this->vrn);
+        $this->mount();
     }
 
     #[On('valid')]

--- a/app/Livewire/Vehicle/SearchVehicle.php
+++ b/app/Livewire/Vehicle/SearchVehicle.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Vehicle;
 
 use App\Models\Vehicle;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Validate;
@@ -29,7 +30,7 @@ class SearchVehicle extends Component
         $vehicle = Vehicle::firstOrCreate(['vrn' => $this->vrn]);
 
         $user = Auth::user();
-        $user->searches()->syncWithoutDetaching([$vehicle->id]);
+        $user->searches()->syncWithoutDetaching([$vehicle->id => ['searched_at' => Carbon::now()]]);
     }
 
     public function usePrevious($vrn): void

--- a/app/Livewire/Vehicle/SearchVehicle.php
+++ b/app/Livewire/Vehicle/SearchVehicle.php
@@ -13,13 +13,6 @@ class SearchVehicle extends Component
     #[Validate('required|filled', as: 'VRN')]
     public $vrn = '';
 
-    public $previousSearches = [];
-
-    public function mount(): void
-    {
-        $this->previousSearches = Auth::user()->searches()->limit(10)->get();
-    }
-
     public function search(): void
     {
         $this->validate();
@@ -28,7 +21,6 @@ class SearchVehicle extends Component
         $this->vrn = str_replace(' ', '', $this->vrn);
 
         $this->dispatch('searched', $this->vrn);
-        $this->mount();
     }
 
     #[On('valid')]

--- a/database/migrations/2025_05_15_144646_add_searched_at_to_user_vehicle.php
+++ b/database/migrations/2025_05_15_144646_add_searched_at_to_user_vehicle.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_vehicle', function (Blueprint $table) {
+            $table->dropTimestamps();
+            $table->timestamp('searched_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_vehicle', function (Blueprint $table) {
+            $table->timestamps();
+            $table->dropColumn('searched_at');
+        });
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -13,7 +13,7 @@
 
             <flux:navlist variant="outline">
                 <flux:navlist.group heading="Platform" class="grid">
-                    <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')">Dashboard</flux:navlist.item>
+                    <flux:navlist.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')">Vehicle Details</flux:navlist.item>
                 </flux:navlist.group>
             </flux:navlist>
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -9,7 +9,7 @@
             </div>
         </div>
         <div class="relative h-full flex-1 rounded-xl border border-neutral-200 dark:border-neutral-700">
-            <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            <livewire:vehicle.display-mot-tests></livewire:vehicle.display-mot-tests>
         </div>
     </div>
 </x-layouts.app>

--- a/resources/views/livewire/vehicle/display-mot-tests.blade.php
+++ b/resources/views/livewire/vehicle/display-mot-tests.blade.php
@@ -1,0 +1,43 @@
+@use(Carbon\Carbon)
+<div class="text-xs text-center p-2 overflow-auto h-full">
+    <style>
+        label {
+            font-weight: bold;
+        }
+    </style>
+
+    <div class="grid grid-cols-5 gap-y-2 my-2 items-center">
+        <label for="dateCompleted">Date Completed</label>
+        <label for="result">Result</label>
+        <label for="odometerReading">Odometer Reading</label>
+        <label class="col-span-2">Defects</label>
+
+        <hr class="col-span-full mx-8">
+
+        @if($motTests)
+            @foreach($motTests as $motTest)
+                <p id="dateCompleted">{{ Carbon::parse($motTest['completedDate'])->format('d-m-Y') ?? '-' }}</p>
+                <p id="result">{{ $motTest['testResult'] ?? '-' }}</p>
+                <p id="odometerReading">{{ $motTest['odometerValue']. ' ' .$motTest['odometerUnit'] ?? '-' }}</p>
+
+                <div class="col-span-2 grid grid-cols-2 gap-y-2 items-center">
+                    @if($motTest['defects'])
+                        @foreach($motTest['defects'] as $defect)
+                            <p>{{ $defect['text'] }}</p>
+                            <p>{{ $defect['type'] }}</p>
+                        @endforeach
+                    @else
+                        <p class="col-span-full">No defects found for this test</p>
+                    @endif
+                </div>
+
+                @if(!$loop->last)
+                    <hr class="col-span-full mx-8 border-gray-500">
+                @endif
+            @endforeach
+        @else
+            <p class="col-span-full">No MOT history found</p>
+        @endif
+    </div>
+</div>
+

--- a/resources/views/livewire/vehicle/search-vehicle.blade.php
+++ b/resources/views/livewire/vehicle/search-vehicle.blade.php
@@ -9,7 +9,7 @@
         <flux:button type="submit" icon="magnifying-glass">Search VRN</flux:button>
     </flux:input.group>
     <div class="text-center w-full grid grid-cols-2 gap-y-3 overflow-hidden py-1">
-        @foreach($previousSearches as $search)
+        @foreach(Auth::user()->searches()->limit(10)->orderByDesc('id')->get() as $search)
             <flux:badge wire:click="usePrevious('{{ $search->vrn }}')" variant="solid" color="yellow" class="justify-self-center self-center w-fit h-fit cursor-pointer">
                 {{ $search->vrn }}
             </flux:badge>

--- a/resources/views/livewire/vehicle/search-vehicle.blade.php
+++ b/resources/views/livewire/vehicle/search-vehicle.blade.php
@@ -9,7 +9,7 @@
         <flux:button type="submit" icon="magnifying-glass">Search VRN</flux:button>
     </flux:input.group>
     <div class="text-center w-full grid grid-cols-2 gap-y-3 overflow-hidden py-1">
-        @foreach(Auth::user()->searches()->limit(10)->orderByDesc('id')->get() as $search)
+        @foreach(Auth::user()->searches()->limit(10)->orderByDesc('searched_at')->get() as $search)
             <flux:badge wire:click="usePrevious('{{ $search->vrn }}')" variant="solid" color="yellow" class="justify-self-center self-center w-fit h-fit cursor-pointer">
                 {{ $search->vrn }}
             </flux:badge>


### PR DESCRIPTION
Displays the MOT history for a searched VRN within a readable table

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/eb367c74-cd83-4772-b409-cd7cdf2e0208" />

Also sharpens up some logic from the previous functionality